### PR TITLE
Ensure to update pip before starting the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis codecov codacy-coverage
+install: pip install -U pip tox-travis codecov codacy-coverage
 
 # Command to run tests, e.g. python setup.py test
 script: tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,7 @@ environment:
       TOX_ENV: "py36"
 
 install:
-  - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/Scripts/pip install wheel"
+  - "%PYTHON%/python.exe -m pip install -U pip tox wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-pip==9.0.1
 bumpversion==0.5.3
 wheel==0.30.0
 watchdog==0.8.3


### PR DESCRIPTION
Specially on Windows this is important, because pip cannot update itself when using pip.exe, which is what is used inside `tox.ini`. This is the reason why #3 failed.